### PR TITLE
Adding HTML Processing Nodes to COSIG.Nodes.Web namespace

### DIFF
--- a/COSIG/Nodes/Web/HTMLDownloaderNode.cs
+++ b/COSIG/Nodes/Web/HTMLDownloaderNode.cs
@@ -32,12 +32,17 @@ namespace COSIG.Nodes.Web
                 if (!item.IsType(typeof(string))) throw new FormatException("Expected string, not " + item.type.ToString());
                 Console.WriteLine(item.data.ToString());
                 string url = item.data.ToString();
+                try
+                {
+                    var htmldoc = web.Load(url);
 
-                var htmldoc = web.Load(url);
+                    Tuple<string, string> htmldata = new Tuple<string, string>(url, htmldoc.DocumentNode.OuterHtml);
+                    Pages.Add(new(htmldata));
+                }
+                catch
+                {
 
-                Tuple<string, string> htmldata = new Tuple<string, string>(url, htmldoc.DocumentNode.OuterHtml);
-                Pages.Add(new(htmldata));
-
+                }
                 ReportProgress("Downloaded " + Pages.Count + "/" + APIObjects.Count + "\t" + url);
 
             }

--- a/COSIG/Nodes/Web/HTMLLinkExtractorNode.cs
+++ b/COSIG/Nodes/Web/HTMLLinkExtractorNode.cs
@@ -1,0 +1,68 @@
+﻿using COSIG.Processing;
+using HtmlAgilityPack;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+
+namespace COSIG.Nodes.Web
+{
+    public class HTMLLinkExtractorNode : Node
+    {
+        List<APIObject> Links = new List<APIObject>();
+
+        public HTMLLinkExtractorNode(string InputFile, string OutputFile) : base(InputFile, OutputFile, typeof(string), typeof(string), "", "HtmlLinkExtractor", "Returns a list of all links in a HTML File")
+        {
+
+        }
+
+
+        public override void Load()
+        {
+            Links.Clear();
+        }
+
+        public override void Work()
+        {
+            foreach(var o in APIObjects)
+            {
+                if (!o.IsType(typeof(string)) & !o.IsType(typeof(Tuple<string, string>))) throw new FormatException("Expected string or Tuple<string, string>, but got " + o.type + " instead");
+                if(o.IsType(typeof(string)))
+                {
+                    HtmlDocument doc = new HtmlDocument();
+                    doc.LoadHtml(o.data.ToString());
+                    var linkedPages = doc.DocumentNode.Descendants("a")
+                                  .Select(a => a.GetAttributeValue("href", null))
+                                  .Where(u => !String.IsNullOrEmpty(u));
+
+                    foreach(string link in linkedPages)
+                    {
+                        Links.Add(new(link));
+                    }
+                }
+                if(o.IsType(typeof(Tuple<string, string>)))
+                {
+                    HtmlDocument doc = new HtmlDocument();
+                    doc.LoadHtml( JsonSerializer.Deserialize<Tuple<string, string>>(o.data.ToString()).Item2);
+                    var linkedPages = doc.DocumentNode.Descendants("a")
+                                  .Select(a => a.GetAttributeValue("href", null))
+                                  .Where(u => !String.IsNullOrEmpty(u));
+
+                    foreach (string link in linkedPages)
+                    {
+                        Links.Add(new(link));
+                    }
+                }
+            }
+        }
+
+        public override void Save(string FilePath)
+        {
+            File.WriteAllText(FilePath, System.Text.Json.JsonSerializer.Serialize(Links));
+        }
+
+    }
+}

--- a/COSIG/Nodes/Web/HTMLRemoverNode.cs
+++ b/COSIG/Nodes/Web/HTMLRemoverNode.cs
@@ -1,0 +1,51 @@
+﻿using COSIG.Processing;
+using HtmlAgilityPack;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace COSIG.Nodes.Web
+{
+    public class HTMLRemoverNode : Node
+    {
+
+        public HTMLRemoverNode(string InputFile, string OutputFile) : base(InputFile, OutputFile, typeof(string), typeof(string), "", "HtmlRemoverNode", "Removes HTML Tags from a HTML String")
+        {
+
+        }
+
+        List<APIObject> CleanPages = new List<APIObject>();
+
+        public override void Load()
+        {
+            CleanPages.Clear();
+        }
+
+
+        public override void Work()
+        {
+            foreach(var p in APIObjects) 
+            {
+                if (!p.IsType(typeof(Tuple<string, string>))) throw new FormatException("Expected type <string, string>, got " + p.type + " instead");
+
+                var tuple = JsonSerializer.Deserialize<Tuple<string, string>>(p.data.ToString());
+
+                var doc = new HtmlDocument();
+                doc.LoadHtml(tuple.Item2);
+                var text = doc.DocumentNode.InnerText;
+
+                CleanPages.Add(new(new Tuple<string, string>(tuple.Item1, text)));
+
+            }
+        }
+
+        public override void Save(string FilePath)
+        {
+            File.WriteAllText(FilePath, System.Text.Json.JsonSerializer.Serialize(CleanPages));
+        }
+
+    }
+}

--- a/COSIGTest/Program.cs
+++ b/COSIGTest/Program.cs
@@ -16,9 +16,12 @@ ProcessingGraph graph = new ProcessingGraph();
 string id0 = graph.AddNode(new EmptyNode("in.json", ""));
 string id1 = graph.AddNode(new HTMLDownloaderNode("", ""));
 string id2 = graph.AddNode(new HTMLRemoverNode("", ""));
+string id1_1 = graph.AddNode(new HTMLLinkExtractorNode("", ""));
 
 graph.AddEdge(new(id0, id1));
 graph.AddEdge(new(id1, id2));
+graph.AddEdge(new(id1, id1_1));
+graph.AddEdge(new(id1_1, id1));
 
 graph.Run();
 

--- a/COSIGTest/Program.cs
+++ b/COSIGTest/Program.cs
@@ -15,8 +15,10 @@ ProcessingGraph graph = new ProcessingGraph();
 
 string id0 = graph.AddNode(new EmptyNode("in.json", ""));
 string id1 = graph.AddNode(new HTMLDownloaderNode("", ""));
+string id2 = graph.AddNode(new HTMLRemoverNode("", ""));
 
 graph.AddEdge(new(id0, id1));
+graph.AddEdge(new(id1, id2));
 
 graph.Run();
 


### PR DESCRIPTION
This branch will merge two additional nodes into the main branch:

**HTML Remover Node**: This node can remove all HTML Tags in an HTML String.
It takes a Tuple<(string with URL), (string with HTML)> as Input and returns the same format with the string stripped of HTML tags.

**HTML Link Extractor Node**: This node rips all links out of a HTML file.
It takes two different input formats: <(string with URL), (string with HTML)> and just (string with HTML).
It returns a list of string API Objects with several URLs.